### PR TITLE
Create withdrawal credential update signature using keystore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bls_to_execution_changes
+bls_to_execution_changes_keystore
 exit_transactions
 validator_keys
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ You can use `generate-bls-to-execution-change-keystore --help` to see all argume
 | `--keystore_password` | String | The password that is used to encrypt the provided keystore. Note: It's not your mnemonic password. |
 | `--validator_index` | Integer | The validator index corresponding to the provided keystore. |
 | `--withdrawal_address` | String. Ethereum execution address in hexadecimal encoded form that you wish to set as your withdrawal credentials. |
-| `--output_folder` | String. Pointing to `./bls_to_execution_changes_keystore` by default | The folder path for the `signed_exit_transaction-*` JSON file |
+| `--output_folder` | String. Pointing to `./bls_to_execution_changes_keystore` by default | The folder path for the `bls_to_execution_change_keystore_signature-*` JSON file |
 | `--devnet_chain_setting` | String. JSON string `'{"network_name": "<NETWORK_NAME>", "genesis_fork_version": "<GENESIS_FORK_VERSION>", "exit_fork_version": "<EXIT_FORK_VERSION>", "genesis_validator_root": "<GENESIS_VALIDATOR_ROOT>"}'` | The custom chain setting of a devnet or testnet. Note that it will override your `--chain` choice. |
 
 ###### `exit-transaction-keystore` Arguments

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
         - [`existing-mnemonic` Arguments](#existing-mnemonic-arguments)
         - [Successful message](#successful-message)
         - [`generate-bls-to-execution-change` Arguments](#generate-bls-to-execution-change-arguments)
+        - [`generate-bls-to-execution-change-keystore` Arguments](#generate-bls-to-execution-change-keystore-arguments)
         - [`exit-transaction-keystore` Arguments](#exit-transaction-keystore-arguments)
         - [`exit-transaction-mnemonic` Arguments](#exit-transaction-mnemonic-arguments)
     - [Option 2. Build `deposit-cli` with native Python](#option-2-build-deposit-cli-with-native-python)
@@ -152,6 +153,7 @@ The CLI offers different commands depending on what you want to do with the tool
 | `new-mnemonic` | (Recommended) This command is used to generate keystores with a new mnemonic. |
 | `existing-mnemonic` | This command is used to re-generate or derive new keys from your existing mnemonic. Use this command, if (i) you have already generated keys with this CLI before, (ii) you want to reuse your mnemonic that you know is secure that you generated elsewhere (reusing your eth wallet mnemonic .etc), or (iii) you lost your keystores and need to recover your keys. |
 | `generate-bls-to-execution-change` | This command is used to generate BLS to execution address change message. This is used to add a withdrawal address to a validator that does not currently have one. |
+| `generate-bls-to-execution-change-keystore` | This command is used to sign a BLS to execution address change message with the provided validator key. This is used for a proposed solution to update withdrawal credentials for users who have lost their mnemonic. |
 | `exit-transaction-keystore` | This command is used to create an exit transaction using a keystore file. |
 | `exit-transaction-mnemonic` | This command is used to create an exit transaction using a mnemonic phrase. |
 
@@ -198,7 +200,7 @@ Your keys can be found at: <YOUR_FOLDER_PATH>
 
 ###### `generate-bls-to-execution-change` Arguments
 
-You can use `bls-to-execution-change --help` to see all arguments. Note that if there are missing arguments that the CLI needs, it will ask you for them.
+You can use `generate-bls-to-execution-change --help` to see all arguments. Note that if there are missing arguments that the CLI needs, it will ask you for them.
 
 | Argument | Type | Description |
 | -------- | -------- | -------- |
@@ -210,6 +212,20 @@ You can use `bls-to-execution-change --help` to see all arguments. Note that if 
 | `--validator_indices` | String of integer(s) | A list of the chosen validator index number(s) as identified on the beacon chain. Split multiple items with whitespaces or commas. |
 | `--bls_withdrawal_credentials_list` | String of hexstring(s). | A list of the old BLS withdrawal credentials of the given validator(s). It is for confirming you are using the correct keys. Split multiple items with whitespaces or commas. |
 | `--withdrawal_address` | String. Ethereum execution address in hexadecimal encoded form | If this field is set and valid, the given execution address will be used to create the withdrawal credentials. Otherwise, it will generate withdrawal credentials with the mnemonic-derived withdrawal public key in [ERC-2334 format](https://eips.ethereum.org/EIPS/eip-2334#eth2-specific-parameters). |
+| `--devnet_chain_setting` | String. JSON string `'{"network_name": "<NETWORK_NAME>", "genesis_fork_version": "<GENESIS_FORK_VERSION>", "exit_fork_version": "<EXIT_FORK_VERSION>", "genesis_validator_root": "<GENESIS_VALIDATOR_ROOT>"}'` | The custom chain setting of a devnet or testnet. Note that it will override your `--chain` choice. |
+
+###### `generate-bls-to-execution-change-keystore` Arguments
+
+You can use `generate-bls-to-execution-change-keystore --help` to see all arguments. Note that if there are missing arguments that the CLI needs, it will ask you for them.
+
+| Argument | Type | Description |
+| -------- | -------- | -------- |
+| `--chain` | String. `mainnet` by default | The chain setting for the signing domain. |
+| `--keystore` | File | The keystore file associating with the validator you wish to sign with. This keystore file should match the provided validator index. |
+| `--keystore_password` | String | The password that is used to encrypt the provided keystore. Note: It's not your mnemonic password. |
+| `--validator_index` | Integer | The validator index corresponding to the provided keystore. |
+| `--withdrawal_address` | String. Ethereum execution address in hexadecimal encoded form that you wish to set as your withdrawal credentials. |
+| `--output_folder` | String. Pointing to `./bls_to_execution_changes_keystore` by default | The folder path for the `signed_exit_transaction-*` JSON file |
 | `--devnet_chain_setting` | String. JSON string `'{"network_name": "<NETWORK_NAME>", "genesis_fork_version": "<GENESIS_FORK_VERSION>", "exit_fork_version": "<EXIT_FORK_VERSION>", "genesis_validator_root": "<GENESIS_VALIDATOR_ROOT>"}'` | The custom chain setting of a devnet or testnet. Note that it will override your `--chain` choice. |
 
 ###### `exit-transaction-keystore` Arguments
@@ -299,6 +315,7 @@ See [here](#commands)
 See [here](#new-mnemonic-arguments) for `new-mnemonic` arguments\
 See [here](#existing-mnemonic-arguments) for `existing-mnemonic` arguments\
 See [here](#generate-bls-to-execution-change-arguments) for `generate-bls-to-execution-change` arguments\
+See [here](#generate-bls-to-execution-change-keystore-arguments) for `generate-bls-to-execution-change-keystore` arguments\
 See [here](#exit-transaction-keystore-arguments) for `exit-transaction-keystore` arguments\
 See [here](#exit-transaction-mnemonic-arguments) for `exit-transaction-mnemonic` arguments
 
@@ -368,6 +385,7 @@ See [here](#commands)
 See [here](#new-mnemonic-arguments) for `new-mnemonic` arguments\
 See [here](#existing-mnemonic-arguments) for `existing-mnemonic` arguments\
 See [here](#generate-bls-to-execution-change-arguments) for `generate-bls-to-execution-change` arguments\
+See [here](#generate-bls-to-execution-change-keystore-arguments) for `generate-bls-to-execution-change-keystore` arguments\
 See [here](#exit-transaction-keystore-arguments) for `exit-transaction-keystore` arguments\
 See [here](#exit-transaction-mnemonic-arguments) for `exit-transaction-mnemonic` arguments
 
@@ -484,6 +502,7 @@ See [here](#commands)
 See [here](#new-mnemonic-arguments) for `new-mnemonic` arguments\
 See [here](#existing-mnemonic-arguments) for `existing-mnemonic` arguments\
 See [here](#generate-bls-to-execution-change-arguments) for `generate-bls-to-execution-change` arguments\
+See [here](#generate-bls-to-execution-change-keystore-arguments) for `generate-bls-to-execution-change-keystore` arguments\
 See [here](#exit-transaction-keystore-arguments) for `exit-transaction-keystore` arguments\
 See [here](#exit-transaction-mnemonic-arguments) for `exit-transaction-mnemonic` arguments
 
@@ -545,9 +564,12 @@ See [here](#commands)
 
 ###### Arguments
 
-See [here](#new-mnemonic-arguments) for `new-mnemonic` arguments
-See [here](#existing-mnemonic-arguments) for `existing-mnemonic` arguments
-See [here](#generate-bls-to-execution-change-arguments) for `generate-bls-to-execution-change` arguments
+See [here](#new-mnemonic-arguments) for `new-mnemonic` arguments\
+See [here](#existing-mnemonic-arguments) for `existing-mnemonic` arguments\
+See [here](#generate-bls-to-execution-change-arguments) for `generate-bls-to-execution-change` arguments\
+See [here](#generate-bls-to-execution-change-keystore-arguments) for `generate-bls-to-execution-change-keystore` arguments\
+See [here](#exit-transaction-keystore-arguments) for `exit-transaction-keystore` arguments\
+See [here](#exit-transaction-mnemonic-arguments) for `exit-transaction-mnemonic` arguments
 
 #### Option 3. Build `deposit-cli` with `virtualenv`
 
@@ -612,6 +634,7 @@ See [here](#commands)
 See [here](#new-mnemonic-arguments) for `new-mnemonic` arguments\
 See [here](#existing-mnemonic-arguments) for `existing-mnemonic` arguments\
 See [here](#generate-bls-to-execution-change-arguments) for `generate-bls-to-execution-change` arguments\
+See [here](#generate-bls-to-execution-change-keystore-arguments) for `generate-bls-to-execution-change-keystore` arguments\
 See [here](#exit-transaction-keystore-arguments) for `exit-transaction-keystore` arguments\
 See [here](#exit-transaction-mnemonic-arguments) for `exit-transaction-mnemonic` arguments
 

--- a/docs/src/generate_bls_to_execution_change_keystore.md
+++ b/docs/src/generate_bls_to_execution_change_keystore.md
@@ -1,0 +1,30 @@
+# generate-bls-to-execution-change-keystore
+
+<div class="warning">
+This command is associated with the a proposed solution to update withdrawal credentials for those who are missing their mnemonic. At this point this has not been approved or implemented and there is no guarantee credentials will be modified in the future.
+</div>
+
+## Description
+Signs a withdrawal credential update message using the provided keystore. This signature is one of the required proofs of ownership for validators who have lost or are missing their mnemonic and are unable to perform the BLS change needed to update their withdrawal credentials.
+
+## Optional Arguments
+
+- **`--chain`**: The chain to use for generating the deposit data. Options are: 'mainnet', 'holesky', etc.
+
+- **`--keystore`**: The keystore file associating with the validator you wish to sign with. This keystore file should match the provided validator index.
+
+- **`--keystore_password`**: The password that is used to encrypt the provided keystore. Note: It's not your mnemonic password. <span class="warning"></span>
+
+- **`--validator_index`**: The validator index corresponding to the provided keystore.
+
+- **`--withdrawal_address`**: Ethereum execution address in hexadecimal encoded form that you wish to set as your withdrawal credentials.
+
+- **`--output_folder`**: The folder path for the `bls_to_execution_change_keystore_signature-*` JSON file.
+
+- **`--devnet_chain_setting`**: The custom chain setting of a devnet or testnet. Note that it will override your `--chain` choice.
+
+## Example Usage
+
+```sh
+./deposit generate-bls-to-execution-change
+```

--- a/docs/src/landing.md
+++ b/docs/src/landing.md
@@ -48,6 +48,8 @@ If there is a specific command you would like to understand more, please choose 
 
 - **[generate-bls-to-execution-change](generate_bls_to_execution_change.md)**: Update your withdrawal credentials of existing validators. It is **required** to have the corresponding mnemonic.
 
+- **[generate-bls-to-execution-change-keystore](generate_bls_to_execution_change_keystore.md)**: Sign an update withdrawal credentials message using your validator keystore.
+
 - **[exit-transaction-keystore](exit_transaction_keystore.md)**: Generate an exit message using the keystore of your validators.
 
 - **[exit-transaction-mnemonic](exit_transaction_mnemonic.md)**: Generate an exit message using the mnemonic of your validators.

--- a/ethstaker_deposit/bls_to_execution_change_keystore.py
+++ b/ethstaker_deposit/bls_to_execution_change_keystore.py
@@ -43,21 +43,25 @@ def bls_to_execution_change_keystore_generation(
     )
 
 
-def export_bls_to_execution_change_keystore_json(folder: str, signed_bls_to_execution_change_keystore: SignedBLSToExecutionChangeKeystore, timestamp: float) -> str:
+def export_bls_to_execution_change_keystore_json(folder: str,
+                                                 signed_execution_change: SignedBLSToExecutionChangeKeystore,
+                                                 timestamp: float) -> str:
     signed_bls_to_execution_change_keystore_json: Dict[str, Any] = {}
+
+    address = '0x' + signed_execution_change.message.to_execution_address.hex()  # type: ignore[attr-defined]
+    index = signed_execution_change.message.validator_index  # type: ignore[attr-defined]
+    signature = '0x' + signed_execution_change.signature.hex()  # type: ignore[attr-defined]
+
     message = {
-        'to_execution_address': '0x' + signed_bls_to_execution_change_keystore.message.to_execution_address.hex(),  # type: ignore[attr-defined]
-        'validator_index': signed_bls_to_execution_change_keystore.message.validator_index,  # type: ignore[attr-defined]
+        'to_execution_address': address,
+        'validator_index': index,
     }
     signed_bls_to_execution_change_keystore_json.update({'message': message})
-    signed_bls_to_execution_change_keystore_json.update({'signature': '0x' + signed_bls_to_execution_change_keystore.signature.hex()})  # type: ignore[attr-defined]
+    signed_bls_to_execution_change_keystore_json.update({'signature': signature})
 
     filefolder = os.path.join(
         folder,
-        'bls_to_execution_change_keystore_transaction-%s-%i.json' % (
-            signed_bls_to_execution_change_keystore.message.validator_index,  # type: ignore[attr-defined]
-            timestamp,
-        )
+        'bls_to_execution_change_keystore_transaction-%s-%i.json' % (index, timestamp)
     )
 
     with open(filefolder, 'w') as f:

--- a/ethstaker_deposit/bls_to_execution_change_keystore.py
+++ b/ethstaker_deposit/bls_to_execution_change_keystore.py
@@ -61,7 +61,7 @@ def export_bls_to_execution_change_keystore_json(folder: str,
 
     filefolder = os.path.join(
         folder,
-        'bls_to_execution_change_keystore_transaction-%s-%i.json' % (index, timestamp)
+        'bls_to_execution_change_keystore_signature-%s-%i.json' % (index, timestamp)
     )
 
     with open(filefolder, 'w') as f:

--- a/ethstaker_deposit/bls_to_execution_change_keystore.py
+++ b/ethstaker_deposit/bls_to_execution_change_keystore.py
@@ -47,7 +47,7 @@ def export_bls_to_execution_change_keystore_json(folder: str, signed_bls_to_exec
     signed_bls_to_execution_change_keystore_json: Dict[str, Any] = {}
     message = {
         'to_execution_address': '0x' + signed_bls_to_execution_change_keystore.message.to_execution_address.hex(),  # type: ignore[attr-defined]
-        'validator_index': str(signed_bls_to_execution_change_keystore.message.validator_index),  # type: ignore[attr-defined]
+        'validator_index': signed_bls_to_execution_change_keystore.message.validator_index,  # type: ignore[attr-defined]
     }
     signed_bls_to_execution_change_keystore_json.update({'message': message})
     signed_bls_to_execution_change_keystore_json.update({'signature': '0x' + signed_bls_to_execution_change_keystore.signature.hex()})  # type: ignore[attr-defined]

--- a/ethstaker_deposit/bls_to_execution_change_keystore.py
+++ b/ethstaker_deposit/bls_to_execution_change_keystore.py
@@ -1,0 +1,67 @@
+import json
+import os
+from typing import Any, Dict
+from eth_typing import HexAddress
+from eth_utils import to_canonical_address
+from py_ecc.bls import G2ProofOfPossession as bls
+
+from ethstaker_deposit.exceptions import ValidationError
+from ethstaker_deposit.settings import BaseChainSetting
+from ethstaker_deposit.utils.ssz import (
+    BLSToExecutionChangeKeystore,
+    SignedBLSToExecutionChangeKeystore,
+    compute_signing_root,
+    compute_bls_to_execution_change_keystore_domain,
+)
+
+
+def bls_to_execution_change_keystore_generation(
+        chain_settings: BaseChainSetting,
+        signing_key: int,
+        execution_address: HexAddress,
+        validator_index: int) -> SignedBLSToExecutionChangeKeystore:
+    if execution_address is None:
+        raise ValueError("The execution address should NOT be empty.")
+    if chain_settings.GENESIS_VALIDATORS_ROOT is None:
+        raise ValidationError("The genesis validators root should NOT be empty "
+                              "for this chain to obtain the BLS to execution change.")
+
+    message = BLSToExecutionChangeKeystore(  # type: ignore[no-untyped-call]
+        validator_index=validator_index,
+        to_execution_address=to_canonical_address(execution_address),
+    )
+    domain = compute_bls_to_execution_change_keystore_domain(
+        fork_version=chain_settings.GENESIS_FORK_VERSION,
+        genesis_validators_root=chain_settings.GENESIS_VALIDATORS_ROOT,
+    )
+    signing_root = compute_signing_root(message, domain)
+    signature = bls.Sign(signing_key, signing_root)
+
+    return SignedBLSToExecutionChangeKeystore(  # type: ignore[no-untyped-call]
+        message=message,
+        signature=signature,
+    )
+
+
+def export_bls_to_execution_change_keystore_json(folder: str, signed_bls_to_execution_change_keystore: SignedBLSToExecutionChangeKeystore, timestamp: float) -> str:
+    signed_bls_to_execution_change_keystore_json: Dict[str, Any] = {}
+    message = {
+        'to_execution_address': '0x' + signed_bls_to_execution_change_keystore.message.to_execution_address.hex(),  # type: ignore[attr-defined]
+        'validator_index': str(signed_bls_to_execution_change_keystore.message.validator_index),  # type: ignore[attr-defined]
+    }
+    signed_bls_to_execution_change_keystore_json.update({'message': message})
+    signed_bls_to_execution_change_keystore_json.update({'signature': '0x' + signed_bls_to_execution_change_keystore.signature.hex()})  # type: ignore[attr-defined]
+
+    filefolder = os.path.join(
+        folder,
+        'bls_to_execution_change_keystore_transaction-%s-%i.json' % (
+            signed_bls_to_execution_change_keystore.message.validator_index,  # type: ignore[attr-defined]
+            timestamp,
+        )
+    )
+
+    with open(filefolder, 'w') as f:
+        json.dump(signed_bls_to_execution_change_keystore_json, f)
+    if os.name == 'posix':
+        os.chmod(filefolder, int('440', 8))  # Read for owner & group
+    return filefolder

--- a/ethstaker_deposit/cli/exit_transaction_keystore.py
+++ b/ethstaker_deposit/cli/exit_transaction_keystore.py
@@ -1,8 +1,9 @@
 import click
 import os
 import time
-
 from typing import Any
+
+from ethstaker_deposit.exceptions import ValidationError
 from ethstaker_deposit.exit_transaction import exit_transaction_generation, export_exit_transaction_json
 from ethstaker_deposit.key_handling.keystore import Keystore
 from ethstaker_deposit.settings import (
@@ -123,7 +124,7 @@ def exit_transaction_keystore(
 
     click.echo(load_text(['msg_verify_exit_transaction']))
     if (not verify_signed_exit_json(saved_folder, keystore.pubkey, chain_settings)):
-        click.echo(['err_verify_exit_transaction'])
+        raise ValidationError(load_text(['err_verify_exit_transaction']))
 
     click.echo(load_text(['msg_creation_success']) + saved_folder)
     click.pause(load_text(['msg_pause']))

--- a/ethstaker_deposit/cli/generate_bls_to_execution_change.py
+++ b/ethstaker_deposit/cli/generate_bls_to_execution_change.py
@@ -48,10 +48,6 @@ from .existing_mnemonic import (
 )
 
 
-def get_password(text: str) -> str:
-    return click.prompt(text, hide_input=True, show_default=False, type=str)
-
-
 def _validate_credentials_match(kwargs: Dict[str, Any]) -> Optional[ValidationError]:
     credential: Credential = kwargs.pop('credential')
     bls_withdrawal_credentials: bytes = kwargs.pop('bls_withdrawal_credentials')

--- a/ethstaker_deposit/cli/generate_bls_to_execution_change_keystore.py
+++ b/ethstaker_deposit/cli/generate_bls_to_execution_change_keystore.py
@@ -14,6 +14,7 @@ from ethstaker_deposit.bls_to_execution_change_keystore import (
     export_bls_to_execution_change_keystore_json,
 )
 from ethstaker_deposit.credentials import Credential
+from ethstaker_deposit.exceptions import ValidationError
 from ethstaker_deposit.key_handling.keystore import Keystore
 from ethstaker_deposit.utils.validation import (
     validate_bls_withdrawal_credentials_matching,
@@ -30,7 +31,6 @@ from ethstaker_deposit.utils.click import (
     choice_prompt_func,
     jit_option,
 )
-from ethstaker_deposit.exceptions import ValidationError
 from ethstaker_deposit.utils.intl import (
     closest_match,
     load_text,
@@ -171,7 +171,7 @@ def generate_bls_to_execution_change_keystore(
 
     click.echo(load_text(['msg_verify_btec']))
     if (not verify_bls_to_execution_change_keystore_json(saved_folder, keystore.pubkey, chain_settings)):
-        click.echo(['err_verify_btec'])
+        raise ValidationError(load_text(['err_verify_btec']))
 
     click.echo(load_text(['msg_creation_success']) + saved_folder)
     click.pause(load_text(['msg_pause']))

--- a/ethstaker_deposit/cli/generate_bls_to_execution_change_keystore.py
+++ b/ethstaker_deposit/cli/generate_bls_to_execution_change_keystore.py
@@ -1,11 +1,7 @@
 import os
 import time
 import click
-from typing import (
-    Any,
-    Dict,
-    Optional
-)
+from typing import Any
 
 from eth_typing import HexAddress
 
@@ -13,11 +9,9 @@ from ethstaker_deposit.bls_to_execution_change_keystore import (
     bls_to_execution_change_keystore_generation,
     export_bls_to_execution_change_keystore_json,
 )
-from ethstaker_deposit.credentials import Credential
 from ethstaker_deposit.exceptions import ValidationError
 from ethstaker_deposit.key_handling.keystore import Keystore
 from ethstaker_deposit.utils.validation import (
-    validate_bls_withdrawal_credentials_matching,
     validate_withdrawal_address,
     validate_int_range,
     validate_keystore_file,
@@ -40,21 +34,6 @@ from ethstaker_deposit.settings import (
     ALL_CHAIN_KEYS,
     get_chain_setting,
 )
-
-
-def get_password(text: str) -> str:
-    return click.prompt(text, hide_input=True, show_default=False, type=str)
-
-
-def _validate_credentials_match(kwargs: Dict[str, Any]) -> Optional[ValidationError]:
-    credential: Credential = kwargs.pop('credential')
-    bls_withdrawal_credentials: bytes = kwargs.pop('bls_withdrawal_credentials')
-
-    try:
-        validate_bls_withdrawal_credentials_matching(bls_withdrawal_credentials, credential)
-    except ValidationError as e:
-        return e
-    return None
 
 
 FUNC_NAME = 'generate_bls_to_execution_change_keystore'

--- a/ethstaker_deposit/cli/generate_bls_to_execution_change_keystore.py
+++ b/ethstaker_deposit/cli/generate_bls_to_execution_change_keystore.py
@@ -1,36 +1,29 @@
 import os
 import time
 import click
-import json
-import concurrent.futures
 from typing import (
     Any,
-    Sequence,
     Dict,
     Optional
 )
 
 from eth_typing import HexAddress
 
-from ethstaker_deposit.bls_to_execution_change_keystore import bls_to_execution_change_keystore_generation, export_bls_to_execution_change_keystore_json
-from ethstaker_deposit.credentials import (
-    CredentialList,
-    Credential
+from ethstaker_deposit.bls_to_execution_change_keystore import (
+    bls_to_execution_change_keystore_generation,
+    export_bls_to_execution_change_keystore_json,
 )
+from ethstaker_deposit.credentials import Credential
 from ethstaker_deposit.key_handling.keystore import Keystore
 from ethstaker_deposit.utils.validation import (
-    validate_bls_withdrawal_credentials_list,
     validate_bls_withdrawal_credentials_matching,
     validate_withdrawal_address,
     validate_int_range,
     validate_keystore_file,
-    verify_bls_to_execution_change_json,
-    validate_validator_indices,
     verify_bls_to_execution_change_keystore_json,
 )
 from ethstaker_deposit.utils.constants import (
     DEFAULT_BLS_TO_EXECUTION_CHANGES_KEYSTORE_FOLDER_NAME,
-    MAX_DEPOSIT_AMOUNT,
 )
 from ethstaker_deposit.utils.click import (
     captive_prompt_callback,
@@ -46,7 +39,6 @@ from ethstaker_deposit.settings import (
     MAINNET,
     ALL_CHAIN_KEYS,
     get_chain_setting,
-    get_devnet_chain_setting,
 )
 
 
@@ -173,7 +165,9 @@ def generate_bls_to_execution_change_keystore(
         os.mkdir(folder)
 
     click.echo(load_text(['msg_key_creation']))
-    saved_folder = export_bls_to_execution_change_keystore_json(folder=folder, signed_bls_to_execution_change_keystore=signed_btec, timestamp=time.time())
+    saved_folder = export_bls_to_execution_change_keystore_json(folder=folder,
+                                                                signed_bls_to_execution_change_keystore=signed_btec,
+                                                                timestamp=time.time())
 
     click.echo(load_text(['msg_verify_btec']))
     if (not verify_bls_to_execution_change_keystore_json(saved_folder, keystore.pubkey, chain_settings)):

--- a/ethstaker_deposit/cli/generate_bls_to_execution_change_keystore.py
+++ b/ethstaker_deposit/cli/generate_bls_to_execution_change_keystore.py
@@ -1,0 +1,183 @@
+import os
+import time
+import click
+import json
+import concurrent.futures
+from typing import (
+    Any,
+    Sequence,
+    Dict,
+    Optional
+)
+
+from eth_typing import HexAddress
+
+from ethstaker_deposit.bls_to_execution_change_keystore import bls_to_execution_change_keystore_generation, export_bls_to_execution_change_keystore_json
+from ethstaker_deposit.credentials import (
+    CredentialList,
+    Credential
+)
+from ethstaker_deposit.key_handling.keystore import Keystore
+from ethstaker_deposit.utils.validation import (
+    validate_bls_withdrawal_credentials_list,
+    validate_bls_withdrawal_credentials_matching,
+    validate_withdrawal_address,
+    validate_int_range,
+    validate_keystore_file,
+    verify_bls_to_execution_change_json,
+    validate_validator_indices,
+    verify_bls_to_execution_change_keystore_json,
+)
+from ethstaker_deposit.utils.constants import (
+    DEFAULT_BLS_TO_EXECUTION_CHANGES_KEYSTORE_FOLDER_NAME,
+    MAX_DEPOSIT_AMOUNT,
+)
+from ethstaker_deposit.utils.click import (
+    captive_prompt_callback,
+    choice_prompt_func,
+    jit_option,
+)
+from ethstaker_deposit.exceptions import ValidationError
+from ethstaker_deposit.utils.intl import (
+    closest_match,
+    load_text,
+)
+from ethstaker_deposit.settings import (
+    MAINNET,
+    ALL_CHAIN_KEYS,
+    get_chain_setting,
+    get_devnet_chain_setting,
+)
+
+
+def get_password(text: str) -> str:
+    return click.prompt(text, hide_input=True, show_default=False, type=str)
+
+
+def _validate_credentials_match(kwargs: Dict[str, Any]) -> Optional[ValidationError]:
+    credential: Credential = kwargs.pop('credential')
+    bls_withdrawal_credentials: bytes = kwargs.pop('bls_withdrawal_credentials')
+
+    try:
+        validate_bls_withdrawal_credentials_matching(bls_withdrawal_credentials, credential)
+    except ValidationError as e:
+        return e
+    return None
+
+
+FUNC_NAME = 'generate_bls_to_execution_change_keystore'
+
+
+@click.command(
+    help=load_text(['arg_generate_bls_to_execution_change', 'help'], func=FUNC_NAME),
+)
+@jit_option(
+    callback=captive_prompt_callback(
+        lambda x: closest_match(x, ALL_CHAIN_KEYS),
+        choice_prompt_func(
+            lambda: load_text(['arg_chain', 'prompt'], func=FUNC_NAME),
+            ALL_CHAIN_KEYS
+        ),
+    ),
+    default=MAINNET,
+    help=lambda: load_text(['arg_chain', 'help'], func=FUNC_NAME),
+    param_decls='--chain',
+    prompt=choice_prompt_func(
+        lambda: load_text(['arg_chain', 'prompt'], func=FUNC_NAME),
+        ALL_CHAIN_KEYS
+    ),
+)
+@jit_option(
+    callback=captive_prompt_callback(
+        lambda file: validate_keystore_file(file),
+        lambda: load_text(['arg_bls_to_execution_changes_keystore_keystore', 'prompt'], func=FUNC_NAME),
+    ),
+    help=lambda: load_text(['arg_bls_to_execution_changes_keystore_keystore', 'help'], func=FUNC_NAME),
+    param_decls='--keystore',
+    prompt=lambda: load_text(['arg_bls_to_execution_changes_keystore_keystore', 'prompt'], func=FUNC_NAME),
+    type=click.Path(exists=True, file_okay=True, dir_okay=False),
+)
+@jit_option(
+    callback=captive_prompt_callback(
+        lambda x: x,
+        lambda: load_text(['arg_bls_to_execution_changes_keystore_keystore_password', 'prompt'], func=FUNC_NAME),
+        None,
+        lambda: load_text(['arg_bls_to_execution_changes_keystore_keystore_password', 'invalid'], func=FUNC_NAME),
+        True,
+    ),
+    help=lambda: load_text(['arg_bls_to_execution_changes_keystore_keystore_password', 'help'], func=FUNC_NAME),
+    hide_input=True,
+    param_decls='--keystore_password',
+    prompt=lambda: load_text(['arg_bls_to_execution_changes_keystore_keystore_password', 'prompt'], func=FUNC_NAME),
+)
+@jit_option(
+    callback=captive_prompt_callback(
+        lambda num: validate_int_range(num, 0, 2**32),
+        lambda: load_text(['arg_validator_index', 'prompt'], func=FUNC_NAME),
+    ),
+    help=lambda: load_text(['arg_validator_index', 'help'], func=FUNC_NAME),
+    param_decls='--validator_index',
+    prompt=lambda: load_text(['arg_validator_index', 'prompt'], func=FUNC_NAME),
+)
+@jit_option(
+    callback=captive_prompt_callback(
+        lambda address: validate_withdrawal_address(None, None, address),
+        lambda: load_text(['arg_withdrawal_address', 'prompt'], func=FUNC_NAME),
+        lambda: load_text(['arg_withdrawal_address', 'confirm'], func=FUNC_NAME),
+        lambda: load_text(['arg_withdrawal_address', 'mismatch'], func=FUNC_NAME),
+    ),
+    help=lambda: load_text(['arg_withdrawal_address', 'help'], func=FUNC_NAME),
+    param_decls=['--withdrawal_address'],
+    prompt=lambda: load_text(['arg_withdrawal_address', 'prompt'], func=FUNC_NAME),
+)
+@jit_option(
+    default=os.getcwd(),
+    help=lambda: load_text(['arg_bls_to_execution_changes_keystore_output_folder', 'help'], func=FUNC_NAME),
+    param_decls='--output_folder',
+    type=click.Path(exists=True, file_okay=False, dir_okay=True),
+)
+@jit_option(
+    # Only for devnet tests
+    default=None,
+    help="[DEVNET ONLY] Set specific GENESIS_FORK_VERSION value",
+    param_decls='--devnet_chain_setting',
+)
+@click.pass_context
+def generate_bls_to_execution_change_keystore(
+        ctx: click.Context,
+        chain: str,
+        keystore: Keystore,
+        keystore_password: str,
+        validator_index: int,
+        withdrawal_address: HexAddress,
+        output_folder: str,
+        **kwargs: Any) -> None:
+    try:
+        secret_bytes = keystore.decrypt(keystore_password)
+    except ValueError:
+        click.echo(load_text(['arg_bls_to_execution_changes_keystore_keystore_password', 'mismatch']))
+        exit(1)
+
+    signing_key = int.from_bytes(secret_bytes, 'big')
+    chain_settings = get_chain_setting(chain)
+
+    signed_btec = bls_to_execution_change_keystore_generation(
+        chain_settings=chain_settings,
+        signing_key=signing_key,
+        validator_index=validator_index,
+        execution_address=withdrawal_address,
+    )
+
+    folder = os.path.join(output_folder, DEFAULT_BLS_TO_EXECUTION_CHANGES_KEYSTORE_FOLDER_NAME)
+    if not os.path.exists(folder):
+        os.mkdir(folder)
+
+    click.echo(load_text(['msg_key_creation']))
+    saved_folder = export_bls_to_execution_change_keystore_json(folder=folder, signed_bls_to_execution_change_keystore=signed_btec, timestamp=time.time())
+
+    click.echo(load_text(['msg_verify_btec']))
+    if (not verify_bls_to_execution_change_keystore_json(saved_folder, keystore.pubkey, chain_settings)):
+        click.echo(['err_verify_btec'])
+
+    click.echo(load_text(['msg_creation_success']) + saved_folder)
+    click.pause(load_text(['msg_pause']))

--- a/ethstaker_deposit/cli/generate_bls_to_execution_change_keystore.py
+++ b/ethstaker_deposit/cli/generate_bls_to_execution_change_keystore.py
@@ -166,7 +166,7 @@ def generate_bls_to_execution_change_keystore(
 
     click.echo(load_text(['msg_key_creation']))
     saved_folder = export_bls_to_execution_change_keystore_json(folder=folder,
-                                                                signed_bls_to_execution_change_keystore=signed_btec,
+                                                                signed_execution_change=signed_btec,
                                                                 timestamp=time.time())
 
     click.echo(load_text(['msg_verify_btec']))

--- a/ethstaker_deposit/cli/generate_keys.py
+++ b/ethstaker_deposit/cli/generate_keys.py
@@ -38,10 +38,6 @@ from ethstaker_deposit.settings import (
 )
 
 
-def get_password(text: str) -> str:
-    return click.prompt(text, hide_input=True, show_default=False, type=str)
-
-
 def generate_keys_arguments_decorator(function: Callable[..., Any]) -> Callable[..., Any]:
     '''
     This is a decorator that, when applied to a parent-command, implements the

--- a/ethstaker_deposit/credentials.py
+++ b/ethstaker_deposit/credentials.py
@@ -33,11 +33,9 @@ from ethstaker_deposit.utils.ssz import (
     compute_bls_to_execution_change_domain,
     compute_signing_root,
     BLSToExecutionChange,
-    BLSToExecutionChangeKeystore,
     DepositData,
     DepositMessage,
     SignedBLSToExecutionChange,
-    SignedBLSToExecutionChangeKeystore,
 )
 
 
@@ -194,7 +192,6 @@ class Credential:
             message=message,
             signature=signature,
         )
-
 
     def get_bls_to_execution_change_dict(self, validator_index: int) -> Dict[str, bytes]:
         result_dict: Dict[str, Any] = {}

--- a/ethstaker_deposit/credentials.py
+++ b/ethstaker_deposit/credentials.py
@@ -33,9 +33,11 @@ from ethstaker_deposit.utils.ssz import (
     compute_bls_to_execution_change_domain,
     compute_signing_root,
     BLSToExecutionChange,
+    BLSToExecutionChangeKeystore,
     DepositData,
     DepositMessage,
     SignedBLSToExecutionChange,
+    SignedBLSToExecutionChangeKeystore,
 )
 
 
@@ -192,6 +194,7 @@ class Credential:
             message=message,
             signature=signature,
         )
+
 
     def get_bls_to_execution_change_dict(self, validator_index: int) -> Dict[str, bytes]:
         result_dict: Dict[str, Any] = {}

--- a/ethstaker_deposit/deposit.py
+++ b/ethstaker_deposit/deposit.py
@@ -8,6 +8,7 @@ from ethstaker_deposit.cli.existing_mnemonic import existing_mnemonic
 from ethstaker_deposit.cli.exit_transaction_keystore import exit_transaction_keystore
 from ethstaker_deposit.cli.exit_transaction_mnemonic import exit_transaction_mnemonic
 from ethstaker_deposit.cli.generate_bls_to_execution_change import generate_bls_to_execution_change
+from ethstaker_deposit.cli.generate_bls_to_execution_change_keystore import generate_bls_to_execution_change_keystore
 from ethstaker_deposit.cli.new_mnemonic import new_mnemonic
 from ethstaker_deposit.exceptions import ValidationError
 from ethstaker_deposit.utils.click import (
@@ -50,6 +51,7 @@ commands = [
     new_mnemonic,
     existing_mnemonic,
     generate_bls_to_execution_change,
+    generate_bls_to_execution_change_keystore,
     exit_transaction_keystore,
     exit_transaction_mnemonic,
 ]

--- a/ethstaker_deposit/intl/en/cli/generate_bls_to_execution_change_keystore.json
+++ b/ethstaker_deposit/intl/en/cli/generate_bls_to_execution_change_keystore.json
@@ -1,0 +1,49 @@
+{
+  "generate_bls_to_execution_change_keystore": {
+      "arg_generate_bls_to_execution_change" :{
+          "help": "Generating the SignedBLSToExecutionChange data to enable withdrawals on Ethereum Beacon Chain."
+      },
+      "arg_withdrawal_address": {
+          "help": "The 20-byte Ethereum execution address that will be used in withdrawal",
+          "prompt": "Please enter the 20-byte execution address for the new withdrawal credentials. Note that you CANNOT change it once you have set it on chain.",
+          "confirm": "Repeat your execution address for confirmation.",
+          "mismatch": "Error: the two entered values do not match. Please type again."
+      },
+      "arg_validator_index": {
+          "help": "The validator index",
+          "prompt": "Please enter the validator index number of your validator as identified on the beacon chain."
+      },
+      "arg_bls_withdrawal_credentials_list": {
+          "help": "A list of 32-byte old BLS withdrawal credentials of the certain validator(s)",
+          "prompt": "Please enter a list of the old BLS withdrawal credentials of your validator(s). Split multiple items with whitespaces or commas. The withdrawal credentials are in hexadecimal encoded form."
+      },
+      "arg_bls_to_execution_changes_keystore_keystore": {
+          "help": "The keystore file associated with the validator you wish to exit.",
+          "prompt": "Please enter the location of your keystore file."
+      },
+      "arg_bls_to_execution_changes_keystore_keystore_password": {
+        "help": "The password that is used to encrypt the provided keystore. Note: It's not your mnemonic password. (It is recommended not to use this argument, and wait for the CLI to ask you for your password as otherwise it will appear in your shell history.)",
+        "prompt": "Enter the password that is used to encrypt the provided keystore.",
+        "mismatch": "Error: The provided keystore password was unable to decrypt this keystore file. Make sure you have the correct password and try again."
+      },
+      "arg_chain": {
+          "help": "The name of Ethereum PoS chain you are targeting. Use \"mainnet\" if you are depositing ETH",
+          "prompt": "Please choose the (mainnet or testnet) network/chain name"
+      },
+      "arg_fork": {
+          "help": "The fork name of the fork you want to signing the message with.",
+          "prompt": "Please choose the fork name of the fork you want to signing the message with."
+      },
+      "arg_bls_to_execution_changes_keystore_folder": {
+          "help": "The folder path for the keystore(s). Pointing to `./bls_to_execution_changes` by default."
+      },
+      "arg_bls_to_execution_changes_keystore_output_folder": {
+          "help": "Folder where you want to save the bls keystore change"
+      },
+      "msg_key_creation": "Creating your SignedBLSToExecutionChangeKeystore.",
+      "msg_verify_btec": "Verifying the bls_to_execution_changes_keystore JSON file.",
+      "msg_creation_success": "\nSuccess!\nYour SignedBLSToExecutionChangeKeystore JSON file can be found at: ",
+      "msg_pause": "\n\nPress any key.",
+      "err_verify_btec": "Failed to verify the bls_to_execution_change_keystore JSON file."
+  }
+}

--- a/ethstaker_deposit/utils/constants.py
+++ b/ethstaker_deposit/utils/constants.py
@@ -11,6 +11,7 @@ ZERO_BYTES32 = b'\x00' * 32
 DOMAIN_DEPOSIT = bytes.fromhex('03000000')
 DOMAIN_VOLUNTARY_EXIT = bytes.fromhex('04000000')
 DOMAIN_BLS_TO_EXECUTION_CHANGE = bytes.fromhex('0A000000')
+DOMAIN_BLS_TO_EXECUTION_CHANGE_KEYSTORE = bytes.fromhex('0B000000')
 BLS_WITHDRAWAL_PREFIX = bytes.fromhex('00')
 EXECUTION_ADDRESS_WITHDRAWAL_PREFIX = bytes.fromhex('01')
 
@@ -23,6 +24,7 @@ MAX_DEPOSIT_AMOUNT = 2 ** 5 * ETH2GWEI
 WORD_LISTS_PATH = os.path.join('ethstaker_deposit', 'key_handling', 'key_derivation', 'word_lists')
 DEFAULT_VALIDATOR_KEYS_FOLDER_NAME = 'validator_keys'
 DEFAULT_BLS_TO_EXECUTION_CHANGES_FOLDER_NAME = 'bls_to_execution_changes'
+DEFAULT_BLS_TO_EXECUTION_CHANGES_KEYSTORE_FOLDER_NAME = 'bls_to_execution_changes_keystore'
 DEFAULT_EXIT_TRANSACTION_FOLDER_NAME = 'exit_transactions'
 
 # Internationalisation constants

--- a/ethstaker_deposit/utils/ssz.py
+++ b/ethstaker_deposit/utils/ssz.py
@@ -82,7 +82,7 @@ def compute_bls_to_execution_change_domain(fork_version: bytes, genesis_validato
 
 def compute_bls_to_execution_change_keystore_domain(fork_version: bytes, genesis_validators_root: bytes) -> bytes:
     """
-    VOLUNTARY_EXIT-only `compute_domain`
+    BLS_TO_EXECUTION_CHANGE_KEYSTORE-only `compute_domain`
     """
     if len(fork_version) != 4:
         raise ValueError(f"Fork version should be in 4 bytes. Got {len(fork_version)}.")

--- a/ethstaker_deposit/utils/ssz.py
+++ b/ethstaker_deposit/utils/ssz.py
@@ -9,6 +9,7 @@ from ssz import (
 )
 from ethstaker_deposit.utils.constants import (
     DOMAIN_BLS_TO_EXECUTION_CHANGE,
+    DOMAIN_BLS_TO_EXECUTION_CHANGE_KEYSTORE,
     DOMAIN_DEPOSIT,
     DOMAIN_VOLUNTARY_EXIT,
     ZERO_BYTES32,
@@ -79,6 +80,17 @@ def compute_bls_to_execution_change_domain(fork_version: bytes, genesis_validato
     return domain_type + fork_data_root[:28]
 
 
+def compute_bls_to_execution_change_keystore_domain(fork_version: bytes, genesis_validators_root: bytes) -> bytes:
+    """
+    VOLUNTARY_EXIT-only `compute_domain`
+    """
+    if len(fork_version) != 4:
+        raise ValueError(f"Fork version should be in 4 bytes. Got {len(fork_version)}.")
+    domain_type = DOMAIN_BLS_TO_EXECUTION_CHANGE_KEYSTORE
+    fork_data_root = compute_fork_data_root(fork_version, genesis_validators_root)
+    return domain_type + fork_data_root[:28]
+
+
 def compute_deposit_fork_data_root(current_version: bytes) -> bytes:
     """
     Return the appropriate ForkData root for a given deposit version.
@@ -142,6 +154,26 @@ class SignedBLSToExecutionChange(Serializable):
     """
     fields = [
         ('message', BLSToExecutionChange),
+        ('signature', bytes96),
+    ]
+
+
+class BLSToExecutionChangeKeystore(Serializable):
+    """
+    Ref: https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#blstoexecutionchange
+    """
+    fields = [
+        ('validator_index', uint64),
+        ('to_execution_address', bytes20),
+    ]
+
+
+class SignedBLSToExecutionChangeKeystore(Serializable):
+    """
+    Ref: https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#signedblstoexecutionchange
+    """
+    fields = [
+        ('message', BLSToExecutionChangeKeystore),
         ('signature', bytes96),
     ]
 

--- a/ethstaker_deposit/utils/validation.py
+++ b/ethstaker_deposit/utils/validation.py
@@ -24,6 +24,7 @@ from ethstaker_deposit.utils.ssz import (
     SignedVoluntaryExit,
     VoluntaryExit,
     compute_bls_to_execution_change_domain,
+    compute_bls_to_execution_change_keystore_domain,
     compute_deposit_domain,
     compute_signing_root,
     compute_voluntary_exit_domain,
@@ -303,7 +304,7 @@ def validate_bls_withdrawal_credentials_matching(bls_withdrawal_credentials: byt
 
 
 #
-# Exit Message Generation
+# Exit Message Validation
 #
 
 
@@ -347,6 +348,11 @@ def validate_signed_exit(validator_index: str,
     return bls.Verify(bls_pubkey, signing_root, bls_signature)
 
 
+#
+# BLS to Execution Change Keystore Validation
+#
+
+
 def verify_bls_to_execution_change_keystore_json(file_folder: str,
                                                  pubkey: str,
                                                  chain_settings: BaseChainSetting) -> bool:
@@ -373,7 +379,7 @@ def validate_bls_to_execution_change_keystore(validator_index: str,
         validator_index=int(validator_index)
     )
 
-    domain = compute_voluntary_exit_domain(
+    domain = compute_bls_to_execution_change_keystore_domain(
         fork_version=chain_settings.GENESIS_FORK_VERSION,
         genesis_validators_root=chain_settings.GENESIS_VALIDATORS_ROOT
     )

--- a/ethstaker_deposit/utils/validation.py
+++ b/ethstaker_deposit/utils/validation.py
@@ -368,7 +368,7 @@ def validate_bls_to_execution_change_keystore(validator_index: str,
     )
 
     domain = compute_voluntary_exit_domain(
-        fork_version=chain_settings.EXIT_FORK_VERSION,
+        fork_version=chain_settings.GENESIS_FORK_VERSION,
         genesis_validators_root=chain_settings.GENESIS_VALIDATORS_ROOT
     )
 

--- a/ethstaker_deposit/utils/validation.py
+++ b/ethstaker_deposit/utils/validation.py
@@ -347,12 +347,18 @@ def validate_signed_exit(validator_index: str,
     return bls.Verify(bls_pubkey, signing_root, bls_signature)
 
 
-def verify_bls_to_execution_change_keystore_json(file_folder: str, pubkey: str, chain_settings: BaseChainSetting) -> bool:
+def verify_bls_to_execution_change_keystore_json(file_folder: str,
+                                                 pubkey: str,
+                                                 chain_settings: BaseChainSetting) -> bool:
     with open(file_folder, 'r', encoding='utf-8') as f:
         deposit_json: SignedBLSToExecutionChangeKeystore = json.load(f)
         signature = deposit_json["signature"]
         message = deposit_json["message"]
-        return validate_bls_to_execution_change_keystore(message["validator_index"], message["to_execution_address"], signature, pubkey, chain_settings)
+        return validate_bls_to_execution_change_keystore(message["validator_index"],
+                                                         message["to_execution_address"],
+                                                         signature,
+                                                         pubkey,
+                                                         chain_settings)
 
 
 def validate_bls_to_execution_change_keystore(validator_index: str,

--- a/tests/test_cli/helpers.py
+++ b/tests/test_cli/helpers.py
@@ -4,6 +4,7 @@ import os
 from ethstaker_deposit.key_handling.keystore import Keystore
 from ethstaker_deposit.utils.constants import (
     DEFAULT_BLS_TO_EXECUTION_CHANGES_FOLDER_NAME,
+    DEFAULT_BLS_TO_EXECUTION_CHANGES_KEYSTORE_FOLDER_NAME,
     DEFAULT_EXIT_TRANSACTION_FOLDER_NAME,
     DEFAULT_VALIDATOR_KEYS_FOLDER_NAME,
 )
@@ -16,6 +17,11 @@ def clean_key_folder(my_folder_path: str) -> None:
 
 def clean_btec_folder(my_folder_path: str) -> None:
     sub_folder_path = os.path.join(my_folder_path, DEFAULT_BLS_TO_EXECUTION_CHANGES_FOLDER_NAME)
+    clean_folder(my_folder_path, sub_folder_path)
+
+
+def clean_btec_keystore_folder(my_folder_path: str) -> None:
+    sub_folder_path = os.path.join(my_folder_path, DEFAULT_BLS_TO_EXECUTION_CHANGES_KEYSTORE_FOLDER_NAME)
     clean_folder(my_folder_path, sub_folder_path)
 
 

--- a/tests/test_cli/test_generate_bls_to_execution_change_keystore.py
+++ b/tests/test_cli/test_generate_bls_to_execution_change_keystore.py
@@ -1,0 +1,81 @@
+import os
+import time
+
+from click.testing import CliRunner
+
+from ethstaker_deposit.credentials import Credential
+from ethstaker_deposit.deposit import cli
+from ethstaker_deposit.settings import get_chain_setting
+from ethstaker_deposit.utils.constants import DEFAULT_BLS_TO_EXECUTION_CHANGES_KEYSTORE_FOLDER_NAME
+from .helpers import (
+    clean_btec_keystore_folder,
+    clean_key_folder,
+    prepare_testing_folder,
+    read_json_file,
+    verify_file_permission,
+)
+
+
+def test_existing_mnemonic_bls_change_keystore() -> None:
+    # Prepare folder
+    my_folder_path = prepare_testing_folder(os)
+    changes_folder_path = os.path.join(my_folder_path, DEFAULT_BLS_TO_EXECUTION_CHANGES_KEYSTORE_FOLDER_NAME)
+
+    clean_key_folder(my_folder_path)
+    if not os.path.exists(my_folder_path):
+        os.mkdir(my_folder_path)
+    if not os.path.exists(changes_folder_path):
+        os.mkdir(changes_folder_path)
+
+    # Shared parameters
+    chain = 'mainnet'
+    keystore_password = 'solo-stakers'
+
+    # Prepare credential
+    credential = Credential(
+        mnemonic='aban aban aban aban aban aban aban aban aban aban aban abou',
+        mnemonic_password='',
+        index=0,
+        amount=0,
+        chain_setting=get_chain_setting(chain),
+        hex_withdrawal_address=None
+    )
+
+    # Save keystore file
+    keystore_filepath = credential.save_signing_keystore(keystore_password, changes_folder_path, time.time())
+
+    runner = CliRunner()
+    arguments = [
+        '--language', 'english',
+        '--non_interactive',
+        'generate-bls-to-execution-change-keystore',
+        '--output_folder', my_folder_path,
+        '--chain', chain,
+        '--keystore', keystore_filepath,
+        '--keystore_password', keystore_password,
+        '--validator_index', '1',
+        '--withdrawal_address', '0xcd60A5f152724480c3a95E4Ff4dacEEf4074854d',
+    ]
+    result = runner.invoke(cli, arguments)
+
+    assert result.exit_code == 0
+
+    # Check files
+    _, _, files = next(os.walk(changes_folder_path))
+
+    change_files = [f for f in files if 'bls_to_execution_change_keystore_' in f]
+
+    assert len(set(change_files)) == 1
+
+    json_data = read_json_file(changes_folder_path, change_files[0])
+
+    # Verify file content
+    assert json_data['message']['to_execution_address'] == '0xcd60a5f152724480c3a95e4ff4daceef4074854d'
+    assert json_data['message']['validator_index'] == 1
+    assert json_data['signature']
+
+    # Verify file permissions
+    verify_file_permission(os, folder_path=changes_folder_path, files=change_files)
+
+    # Clean up
+    clean_btec_keystore_folder(my_folder_path)

--- a/tests/test_cli/test_generate_bls_to_execution_change_keystore.py
+++ b/tests/test_cli/test_generate_bls_to_execution_change_keystore.py
@@ -7,6 +7,7 @@ from ethstaker_deposit.credentials import Credential
 from ethstaker_deposit.deposit import cli
 from ethstaker_deposit.settings import get_chain_setting
 from ethstaker_deposit.utils.constants import DEFAULT_BLS_TO_EXECUTION_CHANGES_KEYSTORE_FOLDER_NAME
+from ethstaker_deposit.utils.intl import load_text
 from .helpers import (
     clean_btec_keystore_folder,
     clean_key_folder,
@@ -16,8 +17,7 @@ from .helpers import (
 )
 
 
-def test_existing_mnemonic_bls_change_keystore() -> None:
-    # Prepare folder
+def test_bls_change_keystore() -> None:
     my_folder_path = prepare_testing_folder(os)
     changes_folder_path = os.path.join(my_folder_path, DEFAULT_BLS_TO_EXECUTION_CHANGES_KEYSTORE_FOLDER_NAME)
 
@@ -27,11 +27,9 @@ def test_existing_mnemonic_bls_change_keystore() -> None:
     if not os.path.exists(changes_folder_path):
         os.mkdir(changes_folder_path)
 
-    # Shared parameters
     chain = 'mainnet'
     keystore_password = 'solo-stakers'
 
-    # Prepare credential
     credential = Credential(
         mnemonic='aban aban aban aban aban aban aban aban aban aban aban abou',
         mnemonic_password='',
@@ -41,7 +39,6 @@ def test_existing_mnemonic_bls_change_keystore() -> None:
         hex_withdrawal_address=None
     )
 
-    # Save keystore file
     keystore_filepath = credential.save_signing_keystore(keystore_password, changes_folder_path, time.time())
 
     runner = CliRunner()
@@ -60,7 +57,6 @@ def test_existing_mnemonic_bls_change_keystore() -> None:
 
     assert result.exit_code == 0
 
-    # Check files
     _, _, files = next(os.walk(changes_folder_path))
 
     change_files = [f for f in files if 'bls_to_execution_change_keystore_' in f]
@@ -69,13 +65,216 @@ def test_existing_mnemonic_bls_change_keystore() -> None:
 
     json_data = read_json_file(changes_folder_path, change_files[0])
 
-    # Verify file content
     assert json_data['message']['to_execution_address'] == '0xcd60a5f152724480c3a95e4ff4daceef4074854d'
     assert json_data['message']['validator_index'] == 1
     assert json_data['signature']
 
-    # Verify file permissions
     verify_file_permission(os, folder_path=changes_folder_path, files=change_files)
 
-    # Clean up
+    clean_btec_keystore_folder(my_folder_path)
+
+
+def test_bls_change_keystore_with_pbkdf2() -> None:
+    pbkdf2_folder_path = os.path.join(os.getcwd(), 'TESTING_TEMP_FOLDER')
+    pbkdf2_bls_change_folder_path = os.path.join(pbkdf2_folder_path,
+                                                 DEFAULT_BLS_TO_EXECUTION_CHANGES_KEYSTORE_FOLDER_NAME)
+    clean_btec_keystore_folder(pbkdf2_folder_path)
+    scrypt_folder_path = os.path.join(os.getcwd(), 'TESTING_TEMP_FOLDER2')
+    scrypt_bls_change_folder_path = os.path.join(scrypt_folder_path,
+                                                 DEFAULT_BLS_TO_EXECUTION_CHANGES_KEYSTORE_FOLDER_NAME)
+    clean_btec_keystore_folder(pbkdf2_folder_path)
+    if not os.path.exists(pbkdf2_folder_path):
+        os.mkdir(pbkdf2_folder_path)
+    if not os.path.exists(scrypt_folder_path):
+        os.mkdir(scrypt_folder_path)
+    if not os.path.exists(pbkdf2_bls_change_folder_path):
+        os.mkdir(pbkdf2_bls_change_folder_path)
+    if not os.path.exists(scrypt_bls_change_folder_path):
+        os.mkdir(scrypt_bls_change_folder_path)
+
+    chain = 'mainnet'
+    keystore_password = 'solo-stakers'
+
+    pbkdf2_credential = Credential(
+        mnemonic='aban aban aban aban aban aban aban aban aban aban aban abou',
+        mnemonic_password='',
+        index=0,
+        amount=0,
+        chain_setting=get_chain_setting(chain),
+        hex_withdrawal_address=None,
+        use_pbkdf2=True,
+    )
+    scrypt_credential = Credential(
+        mnemonic='aban aban aban aban aban aban aban aban aban aban aban abou',
+        mnemonic_password='',
+        index=0,
+        amount=0,
+        chain_setting=get_chain_setting(chain),
+        hex_withdrawal_address=None,
+        use_pbkdf2=False,
+    )
+
+    pbkdf2_keystore_filepath = pbkdf2_credential.save_signing_keystore(
+        keystore_password,
+        pbkdf2_bls_change_folder_path,
+        time.time(),
+    )
+    scrypt_keystore_filepath = scrypt_credential.save_signing_keystore(
+        keystore_password,
+        scrypt_bls_change_folder_path,
+        time.time(),
+    )
+
+    runner = CliRunner()
+    arguments = [
+        '--language', 'english',
+        '--non_interactive',
+        'generate-bls-to-execution-change-keystore',
+        '--output_folder', pbkdf2_folder_path,
+        '--chain', chain,
+        '--keystore', pbkdf2_keystore_filepath,
+        '--keystore_password', keystore_password,
+        '--validator_index', '1',
+        '--withdrawal_address', '0xcd60A5f152724480c3a95E4Ff4dacEEf4074854d',
+    ]
+    result = runner.invoke(cli, arguments)
+    assert result.exit_code == 0
+
+    arguments = [
+        '--language', 'english',
+        '--non_interactive',
+        'generate-bls-to-execution-change-keystore',
+        '--output_folder', scrypt_folder_path,
+        '--chain', chain,
+        '--keystore', scrypt_keystore_filepath,
+        '--keystore_password', keystore_password,
+        '--validator_index', '1',
+        '--withdrawal_address', '0xcd60A5f152724480c3a95E4Ff4dacEEf4074854d',
+    ]
+    result = runner.invoke(cli, arguments)
+    assert result.exit_code == 0
+
+    # Check files
+    _, _, bls_change_files = next(os.walk(pbkdf2_bls_change_folder_path))
+    pbkdf2_bls_change_files = [f for f in bls_change_files if 'bls_to_execution_change_keystore_' in f]
+    assert len(set(pbkdf2_bls_change_files)) == 1
+    pbkdf2_json_data = read_json_file(pbkdf2_bls_change_folder_path, pbkdf2_bls_change_files[0])
+
+    _, _, bls_change_files = next(os.walk(scrypt_bls_change_folder_path))
+    scrypt_bls_change_files = [f for f in bls_change_files if 'bls_to_execution_change_keystore_' in f]
+    assert len(set(scrypt_bls_change_files)) == 1
+    scrypt_json_data = read_json_file(scrypt_bls_change_folder_path, scrypt_bls_change_files[0])
+
+    assert pbkdf2_json_data['message']['to_execution_address'] == scrypt_json_data['message']['to_execution_address']
+    assert pbkdf2_json_data['message']['validator_index'] == scrypt_json_data['message']['validator_index']
+    assert pbkdf2_json_data['signature'] == scrypt_json_data['signature']
+
+    verify_file_permission(os, folder_path=pbkdf2_bls_change_folder_path, files=pbkdf2_bls_change_files)
+    verify_file_permission(os, folder_path=scrypt_bls_change_folder_path, files=scrypt_bls_change_files)
+
+    clean_btec_keystore_folder(pbkdf2_folder_path)
+    clean_btec_keystore_folder(scrypt_folder_path)
+
+
+def test_invalid_keystore_path() -> None:
+    my_folder_path = os.path.join(os.getcwd(), 'TESTING_TEMP_FOLDER')
+    clean_btec_keystore_folder(my_folder_path)
+
+    invalid_keystore_file = os.path.join(os.getcwd(), 'README.md')
+
+    runner = CliRunner()
+    inputs = []
+    data = '\n'.join(inputs)
+    arguments = [
+        '--language', 'english',
+        '--non_interactive',
+        'generate-bls-to-execution-change-keystore',
+        '--output_folder', my_folder_path,
+        '--chain', "mainnet",
+        '--keystore', invalid_keystore_file,
+        '--keystore_password', "password",
+        '--validator_index', '1',
+        '--withdrawal_address', '0xcd60A5f152724480c3a95E4Ff4dacEEf4074854d',
+    ]
+    result = runner.invoke(cli, arguments, input=data)
+
+    assert result.exit_code == 2
+
+    clean_btec_keystore_folder(my_folder_path)
+
+
+def test_invalid_keystore_file() -> None:
+    my_folder_path = os.path.join(os.getcwd(), 'TESTING_TEMP_FOLDER')
+    clean_btec_keystore_folder(my_folder_path)
+
+    runner = CliRunner()
+    inputs = []
+    data = '\n'.join(inputs)
+    arguments = [
+        '--language', 'english',
+        '--non_interactive',
+        'generate-bls-to-execution-change-keystore',
+        '--output_folder', my_folder_path,
+        '--chain', "mainnet",
+        '--keystore', "invalid_keystore_file",
+        '--keystore_password', "password",
+        '--validator_index', '1',
+        '--withdrawal_address', '0xcd60A5f152724480c3a95E4Ff4dacEEf4074854d',
+    ]
+    result = runner.invoke(cli, arguments, input=data)
+
+    assert result.exit_code == 2
+
+    clean_btec_keystore_folder(my_folder_path)
+
+
+def test_invalid_keystore_password() -> None:
+    my_folder_path = os.path.join(os.getcwd(), 'TESTING_TEMP_FOLDER')
+    bls_change_folder_path = os.path.join(my_folder_path, DEFAULT_BLS_TO_EXECUTION_CHANGES_KEYSTORE_FOLDER_NAME)
+    clean_btec_keystore_folder(my_folder_path)
+    if not os.path.exists(my_folder_path):
+        os.mkdir(my_folder_path)
+    if not os.path.exists(bls_change_folder_path):
+        os.mkdir(bls_change_folder_path)
+
+    chain = 'mainnet'
+    keystore_password = 'solo-stakers'
+
+    credential = Credential(
+        mnemonic='aban aban aban aban aban aban aban aban aban aban aban abou',
+        mnemonic_password='',
+        index=0,
+        amount=0,
+        chain_setting=get_chain_setting(chain),
+        hex_withdrawal_address=None
+    )
+
+    keystore_filepath = credential.save_signing_keystore(keystore_password, bls_change_folder_path, time.time())
+    runner = CliRunner()
+    inputs = []
+    data = '\n'.join(inputs)
+    arguments = [
+        '--language', 'english',
+        '--non_interactive',
+        'generate-bls-to-execution-change-keystore',
+        '--output_folder', my_folder_path,
+        '--chain', "mainnet",
+        '--keystore', keystore_filepath,
+        '--keystore_password', "incorrect_password",
+        '--validator_index', '1',
+        '--withdrawal_address', '0xcd60A5f152724480c3a95E4Ff4dacEEf4074854d',
+    ]
+    result = runner.invoke(cli, arguments, input=data)
+
+    assert result.exit_code == 1
+
+    mnemonic_json_file = os.path.join(os.getcwd(),
+                                      'ethstaker_deposit/cli/',
+                                      'generate_bls_to_execution_change_keystore.json')
+    assert load_text(
+        ['arg_bls_to_execution_changes_keystore_keystore_password', 'mismatch'],
+        mnemonic_json_file,
+        'generate_bls_to_execution_change_keystore'
+    ) in result.output
+
     clean_btec_keystore_folder(my_folder_path)


### PR DESCRIPTION
Playing around with the an idea of utilizing the keystore to generate a message to change BLS credentials of a single validator.

If this generated signed message was sent from the execution layer from the validators deposit address there is an argument to be made that it could prove sufficient ownership in lieu of a lost mnemonic